### PR TITLE
Create dashboard layout with header and sidebar

### DIFF
--- a/app/dashboard/_components/dashboard-shell.tsx
+++ b/app/dashboard/_components/dashboard-shell.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import { Header } from "./header";
+import { Sidebar } from "./sidebar";
+
+type DashboardShellProps = {
+  children: React.ReactNode;
+  displayName?: string | null;
+};
+
+export function DashboardShell({ children, displayName }: DashboardShellProps) {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  return (
+    <Box sx={{ display: "flex", minHeight: "100vh", bgcolor: "#f1f5f9" }}>
+      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          minHeight: "100vh",
+        }}
+      >
+        <Paper
+          elevation={0}
+          square
+          sx={{
+            bgcolor: "#b92626",
+            color: "common.white",
+            borderRadius: 0,
+          }}
+        >
+          <Header onMenuClick={() => setIsSidebarOpen(true)} displayName={displayName} />
+        </Paper>
+
+        <Stack component="main" spacing={3} sx={{ flex: 1, p: { xs: 2, md: 4 } }}>
+          {children}
+        </Stack>
+      </Box>
+    </Box>
+  );
+}

--- a/app/dashboard/_components/header.tsx
+++ b/app/dashboard/_components/header.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useMemo } from "react";
+import AppBar from "@mui/material/AppBar";
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
+import MenuIcon from "@mui/icons-material/Menu";
+import NotificationsNoneOutlinedIcon from "@mui/icons-material/NotificationsNoneOutlined";
+import LanguageOutlinedIcon from "@mui/icons-material/LanguageOutlined";
+import AccountCircleIcon from "@mui/icons-material/AccountCircle";
+import { signOut } from "next-auth/react";
+
+const ACTION_ICON_STYLE = {
+  bgcolor: "rgba(255,255,255,0.12)",
+  color: "common.white",
+  borderRadius: 2,
+  "&:hover": { bgcolor: "rgba(255,255,255,0.2)" },
+};
+
+const AVATAR_STYLE = {
+  width: 36,
+  height: 36,
+  bgcolor: "rgba(255,255,255,0.2)",
+  color: "common.white",
+};
+
+type HeaderProps = {
+  onMenuClick: () => void;
+  displayName?: string | null;
+};
+
+export function Header({ onMenuClick, displayName }: HeaderProps) {
+  const userInitial = useMemo(
+    () => (displayName ? displayName.charAt(0).toUpperCase() : null),
+    [displayName]
+  );
+
+  const handleLogout = () => {
+    void signOut({ callbackUrl: "/login" });
+  };
+
+  return (
+    <AppBar
+      position="static"
+      elevation={0}
+      sx={{
+        bgcolor: "transparent",
+        color: "common.white",
+        px: { xs: 2, md: 4 },
+      }}
+    >
+      <Toolbar disableGutters sx={{ justifyContent: "space-between" }}>
+        <IconButton
+          edge="start"
+          onClick={onMenuClick}
+          sx={{ display: { md: "none" }, ...ACTION_ICON_STYLE }}
+        >
+          <MenuIcon />
+        </IconButton>
+
+        <Box sx={{ flexGrow: 1 }} />
+
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          <IconButton size="small" sx={ACTION_ICON_STYLE}>
+            <NotificationsNoneOutlinedIcon fontSize="medium" />
+          </IconButton>
+
+          <IconButton size="small" sx={ACTION_ICON_STYLE}>
+            <LanguageOutlinedIcon />
+          </IconButton>
+
+          <IconButton size="small" sx={ACTION_ICON_STYLE} onClick={handleLogout}>
+            <LogoutOutlinedIcon fontSize="medium" />
+          </IconButton>
+
+          <Divider orientation="vertical" flexItem sx={{ borderColor: "rgba(255,255,255,0.4)" }} />
+
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Avatar sx={AVATAR_STYLE}>
+              {userInitial ? userInitial : <AccountCircleIcon fontSize="small" />}
+            </Avatar>
+            {displayName && (
+              <Typography
+                variant="body2"
+                fontWeight={600}
+                sx={{ display: { xs: "none", sm: "block" } }}
+              >
+                {displayName}
+              </Typography>
+            )}
+          </Stack>
+        </Stack>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/app/dashboard/_components/sidebar.tsx
+++ b/app/dashboard/_components/sidebar.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { Fragment, ReactNode, forwardRef, useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Collapse from "@mui/material/Collapse";
+import Divider from "@mui/material/Divider";
+import Drawer from "@mui/material/Drawer";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Stack from "@mui/material/Stack";
+import AssessmentIcon from "@mui/icons-material/Assessment";
+import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import CampaignIcon from "@mui/icons-material/Campaign";
+import CloseIcon from "@mui/icons-material/Close";
+import Diversity3Icon from "@mui/icons-material/Diversity3";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Inventory2Icon from "@mui/icons-material/Inventory2";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+import MonetizationOnIcon from "@mui/icons-material/MonetizationOn";
+import PersonIcon from "@mui/icons-material/Person";
+import SecurityOutlinedIcon from "@mui/icons-material/SecurityOutlined";
+import Image from "next/image";
+import Link, { LinkProps } from "next/link";
+import { usePathname } from "next/navigation";
+
+const BRAND_COLOR = "#b92626";
+const ACTIVE_BACKGROUND = "#991b1b";
+const HOVER_BACKGROUND = "#991b1b";
+const CHILD_TEXT_COLOR = "rgba(255,255,255,0.7)";
+
+export const SIDEBAR_WIDTH = 230;
+
+type NavChild = {
+  href: string;
+  label: string;
+};
+
+type NavItem = {
+  href: string;
+  label: string;
+  icon: ReactNode;
+  children?: NavChild[];
+};
+
+const navItems: NavItem[] = [
+  {
+    href: "/dashboard",
+    label: "รายงาน",
+    icon: <AssessmentIcon fontSize="small" />,
+    children: [
+      { href: "/dashboard/reports/overview", label: "รายงานภาพรวม" },
+      { href: "/dashboard/reports/sales", label: "รายงานการขาย" },
+      { href: "/dashboard/reports/marketing", label: "รายงานการตลาด" },
+      { href: "/dashboard/reports/activity", label: "รายงานกิจกรรม" },
+    ],
+  },
+  {
+    href: "/dashboard/activities",
+    label: "กิจกรรม",
+    icon: <AssignmentIndIcon fontSize="small" />,
+  },
+  {
+    href: "/dashboard/calendar",
+    label: "ปฏิทิน",
+    icon: <CalendarMonthIcon fontSize="small" />,
+  },
+  {
+    href: "/dashboard/map",
+    label: "แผนที่",
+    icon: <LocationOnIcon fontSize="small" />,
+  },
+  {
+    href: "/dashboard/products",
+    label: "สินค้า",
+    icon: <Inventory2Icon fontSize="small" />,
+  },
+  {
+    href: "/dashboard/sales",
+    label: "การขาย",
+    icon: <MonetizationOnIcon fontSize="small" />,
+    children: [
+      { href: "/dashboard/sales/orders", label: "รายการขาย" },
+      { href: "/dashboard/sales/quotations", label: "ใบเสนอราคา" },
+    ],
+  },
+  {
+    href: "/dashboard/marketing",
+    label: "การตลาด",
+    icon: <CampaignIcon fontSize="small" />,
+  },
+  {
+    href: "/dashboard/customers",
+    label: "ลูกค้า",
+    icon: <PersonIcon fontSize="small" />,
+  },
+  {
+    href: "/dashboard/employees",
+    label: "พนักงาน",
+    icon: <Diversity3Icon fontSize="small" />,
+  },
+  {
+    href: "/dashboard/roles",
+    label: "สิทธิ์",
+    icon: <SecurityOutlinedIcon fontSize="small" />,
+  },
+];
+
+type NavLinkProps = {
+  item: NavItem;
+  depth?: number;
+  isOpen: boolean;
+  onToggle: () => void;
+  onLinkClick: () => void;
+  pathname: string;
+};
+
+type LinkBehaviorProps = LinkProps & { children?: React.ReactNode };
+
+const LinkBehavior = forwardRef<HTMLAnchorElement, LinkBehaviorProps>(function LinkBehavior(
+  { href, ...other },
+  ref
+) {
+  return <Link ref={ref} href={href} {...other} />;
+});
+
+function NavLink({ item, depth = 0, isOpen, onToggle, onLinkClick, pathname }: NavLinkProps) {
+  const isActive = item.children
+    ? item.children.some((child) => pathname.startsWith(child.href))
+    : pathname === item.href;
+
+  if (item.children?.length) {
+    return (
+      <Fragment>
+        <ListItemButton
+          onClick={onToggle}
+          sx={{
+            borderRadius: 4,
+            pl: depth ? 4 : 2,
+            mx: 1,
+            bgcolor: isActive ? ACTIVE_BACKGROUND : "transparent",
+            "&:hover": { bgcolor: HOVER_BACKGROUND },
+          }}
+        >
+          <ListItemIcon sx={{ color: "inherit", minWidth: 36 }}>
+            {item.icon}
+          </ListItemIcon>
+          <ListItemText primary={item.label} />
+          {isOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </ListItemButton>
+        <Collapse in={isOpen} timeout="auto" unmountOnExit>
+          <Box
+            sx={{
+              bgcolor: "#991b1b",
+              borderRadius: 3,
+              mx: 1,
+              my: 0.5,
+              p: 0.5,
+            }}
+          >
+            <List component="div" disablePadding>
+              {item.children.map((child) => {
+                const childIsActive = pathname === child.href;
+                return (
+                  <ListItemButton
+                    key={child.href}
+                    component={LinkBehavior}
+                    href={child.href}
+                    onClick={onLinkClick}
+                    sx={{
+                      pl: 4,
+                      fontSize: 14,
+                      borderRadius: 2,
+                      color: childIsActive ? "white" : CHILD_TEXT_COLOR,
+                      bgcolor: childIsActive
+                        ? `${ACTIVE_BACKGROUND} !important`
+                        : "transparent",
+                      "&:hover": { bgcolor: `${HOVER_BACKGROUND} !important` },
+                      textDecoration: "none",
+                    }}
+                  >
+                    <ListItemText primary={child.label} />
+                    {childIsActive && (
+                      <Box
+                        component="span"
+                        sx={{
+                          width: 8,
+                          height: 8,
+                          bgcolor: "white",
+                          borderRadius: "50%",
+                          ml: 1.5,
+                        }}
+                      />
+                    )}
+                  </ListItemButton>
+                );
+              })}
+            </List>
+          </Box>
+        </Collapse>
+      </Fragment>
+    );
+  }
+
+  return (
+    <ListItemButton
+      component={LinkBehavior}
+      href={item.href}
+      onClick={onLinkClick}
+      selected={isActive}
+      sx={{
+        borderRadius: 2,
+        pl: depth ? 4 : 2,
+        mx: 1,
+        bgcolor: isActive ? `${ACTIVE_BACKGROUND} !important` : "transparent",
+        "&:hover": { bgcolor: `${HOVER_BACKGROUND} !important` },
+        "&.Mui-selected": {
+          bgcolor: `${ACTIVE_BACKGROUND} !important`,
+          "&:hover": { bgcolor: `${HOVER_BACKGROUND} !important` },
+        },
+        textDecoration: "none",
+        color: "inherit",
+      }}
+    >
+      <ListItemIcon sx={{ color: "inherit", minWidth: 36 }}>
+        {item.icon}
+      </ListItemIcon>
+      <ListItemText primary={item.label} />
+    </ListItemButton>
+  );
+}
+
+type SidebarProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function Sidebar({ isOpen, onClose }: SidebarProps) {
+  const pathname = usePathname();
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+
+  useEffect(() => {
+    const parent = navItems.find((item) =>
+      item.children?.some((child) => pathname.startsWith(child.href))
+    );
+    setOpenMenu(parent ? parent.href : null);
+  }, [pathname]);
+
+  const content = (
+    <Box
+      sx={{
+        width: SIDEBAR_WIDTH,
+        bgcolor: BRAND_COLOR,
+        color: "white",
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
+      <Stack direction="row" justifyContent="center" alignItems="center" py={3}>
+        <Box
+          sx={{
+            width: 150,
+            height: 150,
+            position: "relative",
+            borderRadius: "10%",
+            overflow: "hidden",
+          }}
+        >
+          <Image src="/images/logo.png" alt="Logo" fill style={{ objectFit: "cover" }} />
+        </Box>
+      </Stack>
+
+      <Divider sx={{ borderColor: "rgba(255,255,255,0.2)", mb: 2 }} />
+
+      <List sx={{ flex: 1, overflowY: "auto" }}>
+        {navItems.map((item) => (
+          <NavLink
+            key={item.href}
+            item={item}
+            isOpen={openMenu === item.href}
+            onToggle={() =>
+              setOpenMenu((current) => (current === item.href ? null : item.href))
+            }
+            onLinkClick={onClose}
+            pathname={pathname}
+          />
+        ))}
+      </List>
+    </Box>
+  );
+
+  return (
+    <Fragment>
+      <Drawer
+        anchor="left"
+        open={isOpen}
+        onClose={onClose}
+        sx={{ display: { md: "none" } }}
+        PaperProps={{ sx: { bgcolor: "transparent" } }}
+      >
+        <Box sx={{ position: "absolute", top: 8, right: 8 }}>
+          <IconButton onClick={onClose} sx={{ color: "white" }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        {content}
+      </Drawer>
+
+      <Box sx={{ display: { xs: "none", md: "flex" }, flexShrink: 0 }}>{content}</Box>
+    </Fragment>
+  );
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { DashboardShell } from "./_components/dashboard-shell";
+
+type DashboardLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function DashboardLayout({ children }: DashboardLayoutProps) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return <DashboardShell displayName={session.user?.name}>{children}</DashboardShell>;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,25 +1,28 @@
 import { getServerSession } from "next-auth";
+import { Box, Typography, Paper, Stack } from "@mui/material";
 import { authOptions } from "@/lib/auth";
-import { redirect } from "next/navigation";
-import { Box, Typography, Paper, Stack, Button } from "@mui/material";
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
-  if (!session?.user) redirect("/login");
+  const roleValue = ((session?.user ?? {}) as { role?: unknown }).role;
+  const role = typeof roleValue === "string" ? roleValue : "USER";
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Typography variant="h4" fontWeight={700} mb={2}>Dashboard</Typography>
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" fontWeight={700} mb={1}>
+          Dashboard
+        </Typography>
+        <Typography color="text.secondary">
+          จัดการข้อมูลภาพรวมของระบบได้จากเมนูด้านซ้ายมือ
+        </Typography>
+      </Box>
+
       <Paper sx={{ p: 3 }}>
-        <Stack direction="row" justifyContent="space-between" alignItems="center">
-          <Typography>
-            สวัสดี {session.user?.name ?? "ผู้ใช้"} (role: {(session.user as any).role ?? "USER"})
-          </Typography>
-          <form action="/api/auth/signout" method="post">
-            <Button type="submit" variant="outlined">ออกจากระบบ</Button>
-          </form>
-        </Stack>
+        <Typography>
+          สวัสดี {session?.user?.name ?? "ผู้ใช้"} (role: {role})
+        </Typography>
       </Paper>
-    </Box>
+    </Stack>
   );
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.16.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0)
+      '@mui/icons-material':
+        specifier: ^7.3.2
+        version: 7.3.2(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.13)(react@19.1.0)
       '@mui/material':
         specifier: ^7.3.2
         version: 7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -537,6 +540,17 @@ packages:
 
   '@mui/core-downloads-tracker@7.3.2':
     resolution: {integrity: sha512-AOyfHjyDKVPGJJFtxOlept3EYEdLoar/RvssBTWVAvDJGIE676dLi2oT/Kx+FoVXFoA/JdV7DEMq/BVWV3KHRw==}
+
+  '@mui/icons-material@7.3.2':
+    resolution: {integrity: sha512-TZWazBjWXBjR6iGcNkbKklnwodcwj0SrChCNHc9BhD9rBgET22J1eFhHsEmvSvru9+opDy3umqAimQjokhfJlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^7.3.2
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@mui/material@7.3.2':
     resolution: {integrity: sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==}
@@ -2649,6 +2663,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mui/core-downloads-tracker@7.3.2': {}
+
+  '@mui/icons-material@7.3.2(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.13)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/material': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.13
 
   '@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- add a dashboard layout that wraps the route with the legacy-style header and sidebar navigation
- surface authenticated user details in the new layout, updating auth typing to avoid `any` usage and refreshing the dashboard copy
- include the MUI icons package required for the new UI components

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68da0062234c8323a36d028f181cb15a