### PR TITLE
Add employee management pages with search and forms

### DIFF
--- a/app/dashboard/employees/[employeeId]/edit/page.tsx
+++ b/app/dashboard/employees/[employeeId]/edit/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button, Stack, Typography } from "@mui/material";
+
+import { EmployeeForm } from "../../_components/employee-form";
+import { getEmployeeById } from "../../data";
+
+export default function EmployeeEditPage({
+  params,
+}: {
+  params: { employeeId: string };
+}) {
+  const router = useRouter();
+  const employee = getEmployeeById(params.employeeId);
+
+  if (!employee) {
+    return (
+      <Stack spacing={2}>
+        <Typography variant="h4" fontWeight={700}>
+          ไม่พบข้อมูลพนักงาน
+        </Typography>
+        <Typography color="text.secondary">
+          ไม่พบรหัสพนักงานที่ต้องการแก้ไข กรุณากลับไปยังหน้ารายการพนักงาน
+        </Typography>
+        <Button component={Link} href="/dashboard/employees" variant="contained" sx={{ width: "fit-content" }}>
+          กลับไปหน้าพนักงาน
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={3}>
+      <EmployeeForm
+        title={`แก้ไขข้อมูลพนักงาน (${employee.employeeCode})`}
+        description="ปรับปรุงข้อมูลพนักงาน รวมถึงอีเมลและสถานะการทำงาน"
+        initialValues={{
+          name: employee.name,
+          email: employee.email,
+          password: "",
+          position: employee.position,
+          department: employee.department,
+          phone: employee.phone,
+          startDate: employee.startDate,
+          status: employee.status,
+        }}
+        submitLabel="บันทึกการแก้ไข"
+        onSubmit={async (values) => {
+          console.log("update employee", employee.id, values);
+          router.push("/dashboard/employees");
+        }}
+      />
+      <Typography color="text.secondary">
+        * ตัวอย่างการแก้ไขข้อมูลนี้เป็นการจำลอง ยังไม่มีการเชื่อมต่อฐานข้อมูลจริง
+      </Typography>
+    </Stack>
+  );
+}

--- a/app/dashboard/employees/_components/employee-form.tsx
+++ b/app/dashboard/employees/_components/employee-form.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import type { ChangeEvent, FormEvent } from "react";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Button,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+export type EmployeeFormValues = {
+  name: string;
+  email: string;
+  password: string;
+  position: string;
+  department: string;
+  phone: string;
+  startDate: string;
+  status: "ACTIVE" | "ON_LEAVE" | "INACTIVE";
+};
+
+export type EmployeeFormProps = {
+  title: string;
+  description: string;
+  initialValues: EmployeeFormValues;
+  submitLabel?: string;
+  onSubmit?: (values: EmployeeFormValues) => Promise<void> | void;
+  requirePassword?: boolean;
+};
+
+const statusOptions = [
+  { value: "ACTIVE", label: "ปฏิบัติงาน" },
+  { value: "ON_LEAVE", label: "ลาพัก" },
+  { value: "INACTIVE", label: "ออกจากงาน" },
+];
+
+const departmentOptions = [
+  "วิศวกรรม",
+  "ประสบการณ์ผู้ใช้",
+  "วิเคราะห์ธุรกิจ",
+  "การตลาด",
+  "ทรัพยากรบุคคล",
+  "การเงิน",
+  "บริการลูกค้า",
+];
+
+export function EmployeeForm({
+  title,
+  description,
+  initialValues,
+  submitLabel = "บันทึกข้อมูล",
+  onSubmit,
+  requirePassword = false,
+}: EmployeeFormProps) {
+  const [values, setValues] = useState<EmployeeFormValues>(initialValues);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  const departmentItems = useMemo(
+    () => [...departmentOptions].sort((a, b) => a.localeCompare(b)),
+    [],
+  );
+
+  const handleChange = <Field extends keyof EmployeeFormValues>(
+    field: Field,
+  ) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setValues((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    try {
+      setSubmitting(true);
+      await onSubmit?.(values);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Stack spacing={1}>
+        <Typography variant="h4" fontWeight={700} component="h1">
+          {title}
+        </Typography>
+        <Typography color="text.secondary">{description}</Typography>
+      </Stack>
+
+      <Paper
+        component="form"
+        onSubmit={handleSubmit}
+        sx={{ p: { xs: 2, sm: 3 }, maxWidth: 720 }}
+      >
+        <Stack spacing={3}>
+          <TextField
+            label="ชื่อ-นามสกุล"
+            value={values.name}
+            onChange={handleChange("name")}
+            required
+            placeholder="เช่น สมชาย ใจดี"
+          />
+
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField
+              label="อีเมลสำหรับเข้าสู่ระบบ"
+              value={values.email}
+              onChange={handleChange("email")}
+              type="email"
+              required
+              fullWidth
+              placeholder="name@example.com"
+            />
+            <TextField
+              label="รหัสผ่านเริ่มต้น"
+              value={values.password}
+              onChange={handleChange("password")}
+              type="password"
+              required={requirePassword}
+              helperText="ใช้สำหรับเข้าสู่ระบบครั้งแรก สามารถเปลี่ยนได้ภายหลัง"
+              fullWidth
+            />
+          </Stack>
+
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField
+              label="ตำแหน่งงาน"
+              value={values.position}
+              onChange={handleChange("position")}
+              required
+              fullWidth
+            />
+            <TextField
+              select
+              label="แผนก"
+              value={values.department}
+              onChange={handleChange("department")}
+              required
+              fullWidth
+            >
+              {departmentItems.map((department) => (
+                <MenuItem key={department} value={department}>
+                  {department}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
+
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField
+              label="หมายเลขติดต่อ"
+              value={values.phone}
+              onChange={handleChange("phone")}
+              required
+              fullWidth
+              placeholder="0xx-xxx-xxxx"
+            />
+            <TextField
+              label="วันที่เริ่มงาน"
+              value={values.startDate}
+              onChange={handleChange("startDate")}
+              type="date"
+              InputLabelProps={{ shrink: true }}
+              required
+              fullWidth
+            />
+          </Stack>
+
+          <TextField
+            select
+            label="สถานะการทำงาน"
+            value={values.status}
+            onChange={handleChange("status")}
+            required
+          >
+            {statusOptions.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={2}
+            justifyContent="flex-end"
+          >
+            <Button
+              component={Link}
+              href="/dashboard/employees"
+              variant="outlined"
+              color="inherit"
+            >
+              ยกเลิก
+            </Button>
+            <Button type="submit" variant="contained" disabled={isSubmitting}>
+              {submitLabel}
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+}

--- a/app/dashboard/employees/data.ts
+++ b/app/dashboard/employees/data.ts
@@ -1,0 +1,86 @@
+export type EmployeeStatus = "ACTIVE" | "ON_LEAVE" | "INACTIVE";
+
+export type Employee = {
+  id: string;
+  employeeCode: string;
+  name: string;
+  position: string;
+  department: string;
+  email: string;
+  phone: string;
+  startDate: string;
+  status: EmployeeStatus;
+};
+
+export const EMPLOYEES: Employee[] = [
+  {
+    id: "emp-001",
+    employeeCode: "EMP-001",
+    name: "สมชาย ใจดี",
+    position: "หัวหน้าทีมพัฒนาซอฟต์แวร์",
+    department: "วิศวกรรม",
+    email: "somchai@example.com",
+    phone: "081-111-2233",
+    startDate: "2021-02-15",
+    status: "ACTIVE",
+  },
+  {
+    id: "emp-002",
+    employeeCode: "EMP-002",
+    name: "สุดารัตน์ มงคล",
+    position: "นักวิเคราะห์ระบบ",
+    department: "วิเคราะห์ธุรกิจ",
+    email: "sudarat@example.com",
+    phone: "086-555-8899",
+    startDate: "2020-07-01",
+    status: "ON_LEAVE",
+  },
+  {
+    id: "emp-003",
+    employeeCode: "EMP-003",
+    name: "อนุชา สายชล",
+    position: "นักออกแบบ UX/UI",
+    department: "ประสบการณ์ผู้ใช้",
+    email: "anucha@example.com",
+    phone: "089-333-4556",
+    startDate: "2019-10-20",
+    status: "ACTIVE",
+  },
+  {
+    id: "emp-004",
+    employeeCode: "EMP-004",
+    name: "พิมพ์ลดา ศรีทอง",
+    position: "ผู้จัดการฝ่ายการตลาด",
+    department: "การตลาด",
+    email: "pimlada@example.com",
+    phone: "082-999-4422",
+    startDate: "2018-05-30",
+    status: "ACTIVE",
+  },
+  {
+    id: "emp-005",
+    employeeCode: "EMP-005",
+    name: "ชยพล เกียรติชัย",
+    position: "เจ้าหน้าที่บุคคล",
+    department: "ทรัพยากรบุคคล",
+    email: "chayapon@example.com",
+    phone: "087-777-1122",
+    startDate: "2022-01-10",
+    status: "ACTIVE",
+  },
+  {
+    id: "emp-006",
+    employeeCode: "EMP-006",
+    name: "สุนิสา จิตสกุล",
+    position: "นักบัญชีอาวุโส",
+    department: "การเงิน",
+    email: "sunisa@example.com",
+    phone: "080-212-9876",
+    startDate: "2017-11-05",
+    status: "INACTIVE",
+  },
+];
+
+export function getEmployeeById(id: string): Employee | undefined {
+  return EMPLOYEES.find((employee) => employee.id === id);
+}

--- a/app/dashboard/employees/new/page.tsx
+++ b/app/dashboard/employees/new/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Stack, Typography } from "@mui/material";
+
+import { EmployeeForm } from "../_components/employee-form";
+
+export default function EmployeeCreatePage() {
+  const router = useRouter();
+
+  return (
+    <Stack spacing={3}>
+      <EmployeeForm
+        title="เพิ่มข้อมูลพนักงานใหม่"
+        description="กรอกข้อมูลรายละเอียดพนักงาน รวมถึงอีเมลและรหัสผ่านสำหรับการเข้าสู่ระบบ"
+        initialValues={{
+          name: "",
+          email: "",
+          password: "",
+          position: "",
+          department: "วิศวกรรม",
+          phone: "",
+          startDate: new Date().toISOString().slice(0, 10),
+          status: "ACTIVE",
+        }}
+        submitLabel="เพิ่มพนักงาน"
+        requirePassword
+        onSubmit={async (values) => {
+          console.log("create employee", values);
+          router.push("/dashboard/employees");
+        }}
+      />
+      <Typography color="text.secondary">
+        * ตัวอย่างการบันทึกข้อมูลนี้เป็นการจำลอง ยังไม่มีการเชื่อมต่อฐานข้อมูลจริง
+      </Typography>
+    </Stack>
+  );
+}

--- a/app/dashboard/employees/page.tsx
+++ b/app/dashboard/employees/page.tsx
@@ -1,12 +1,177 @@
-import { Stack, Typography } from "@mui/material";
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Box,
+  Button,
+  Chip,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+
+import type { EmployeeStatus } from "./data";
+import { EMPLOYEES } from "./data";
 
 export default function EmployeesPage() {
+  const [query, setQuery] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredEmployees = useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+    if (!normalized) return EMPLOYEES;
+
+    return EMPLOYEES.filter((employee) =>
+      [
+        employee.employeeCode,
+        employee.name,
+        employee.position,
+        employee.department,
+        employee.email,
+      ]
+        .join(" ")
+        .toLowerCase()
+        .includes(normalized),
+    );
+  }, [searchTerm]);
+
+  const handleSearch = () => {
+    setSearchTerm(query);
+  };
+
+  const handleQueryKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSearch();
+    }
+  };
+
   return (
-    <Stack spacing={2}>
-      <Typography variant="h4" fontWeight={700}>
-        พนักงาน
-      </Typography>
-      <Typography color="text.secondary">หน้าว่างสำหรับการจัดการพนักงาน</Typography>
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: "column", md: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "flex-start", md: "center" }}
+        spacing={2}
+      >
+        <Box>
+          <Typography variant="h4" fontWeight={700} mb={0.5}>
+            พนักงาน
+          </Typography>
+          <Typography color="text.secondary">
+            จัดการข้อมูลพนักงาน และติดตามสถานะการทำงานของทีมได้จากหน้านี้
+          </Typography>
+        </Box>
+        <Button
+          component={Link}
+          href="/dashboard/employees/new"
+          variant="contained"
+          size="large"
+        >
+          เพิ่มพนักงาน
+        </Button>
+      </Stack>
+
+      <Paper sx={{ p: { xs: 2, sm: 3 } }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          alignItems={{ xs: "stretch", sm: "flex-end" }}
+        >
+          <TextField
+            label="ค้นหาพนักงาน"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleQueryKeyDown}
+            placeholder="พิมพ์ชื่อ อีเมล หรือแผนก"
+            fullWidth
+          />
+          <Button
+            variant="outlined"
+            startIcon={<SearchIcon />}
+            onClick={handleSearch}
+            sx={{ minWidth: { sm: 160 } }}
+          >
+            ค้นหา
+          </Button>
+        </Stack>
+      </Paper>
+
+      <TableContainer component={Paper} sx={{ borderRadius: 2 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>รหัส</TableCell>
+              <TableCell>ชื่อ-นามสกุล</TableCell>
+              <TableCell>ตำแหน่ง</TableCell>
+              <TableCell>อีเมล</TableCell>
+              <TableCell>แผนก</TableCell>
+              <TableCell align="center">สถานะ</TableCell>
+              <TableCell align="right">การจัดการ</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filteredEmployees.map((employee) => (
+              <TableRow key={employee.id} hover>
+                <TableCell>{employee.employeeCode}</TableCell>
+                <TableCell>
+                  <Stack spacing={0.5}>
+                    <Typography fontWeight={600}>{employee.name}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      เริ่มงานเมื่อ {new Date(employee.startDate).toLocaleDateString("th-TH")}
+                    </Typography>
+                  </Stack>
+                </TableCell>
+                <TableCell>{employee.position}</TableCell>
+                <TableCell>{employee.email}</TableCell>
+                <TableCell>{employee.department}</TableCell>
+                <TableCell align="center">
+                  <StatusChip status={employee.status} />
+                </TableCell>
+                <TableCell align="right">
+                  <Button
+                    component={Link}
+                    href={`/dashboard/employees/${employee.id}/edit`}
+                    variant="text"
+                  >
+                    แก้ไข
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+            {filteredEmployees.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7}>
+                  <Typography textAlign="center" color="text.secondary" py={4}>
+                    ไม่พบข้อมูลพนักงานที่ตรงกับคำค้นหา
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
     </Stack>
   );
+}
+
+function StatusChip({ status }: { status: EmployeeStatus }) {
+  if (status === "ACTIVE") {
+    return <Chip label="ปฏิบัติงาน" color="success" variant="outlined" />;
+  }
+
+  if (status === "ON_LEAVE") {
+    return <Chip label="ลาพัก" color="warning" variant="outlined" />;
+  }
+
+  return <Chip label="ออกจากงาน" color="default" variant="outlined" />;
 }


### PR DESCRIPTION
## Summary
- build an interactive employee index view with search filtering and quick access to create/edit actions
- add reusable employee form component plus dedicated create and edit pages
- provide a mock employee dataset to populate the dashboard UI

## Testing
- pnpm eslint

------
https://chatgpt.com/codex/tasks/task_e_68da0a4e4de88323a9ac90b91f6927aa