### PR TITLE
Refactor Prisma client soft delete middleware to use $extends

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,7 +1,386 @@
-import { PrismaClient } from "@prisma/client";
+import { AuditAction, Prisma, PrismaClient } from "@prisma/client";
 
-const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+type GlobalPrismaStore = {
+  prisma: PrismaClient | undefined;
+  prismaHelper: PrismaClient | undefined;
+};
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+const globalForPrisma = global as unknown as GlobalPrismaStore;
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+type ReadDelegate = {
+  findFirst?: (args: Record<string, unknown>) => Promise<unknown>;
+  findMany?: (args: Record<string, unknown>) => Promise<unknown>;
+};
+
+const SOFT_DELETE_MODELS = new Set<Prisma.ModelName>([
+  "User",
+  "Employee",
+  "Account",
+  "Session",
+  "VerificationToken",
+  "RoleDefinition",
+  "Permission",
+  "RolePermission",
+  "AuditLog",
+]);
+
+const STATUS_KEYS = ["status", "approvalStatus", "state"];
+
+const ensureHelperClient = () => {
+  if (!globalForPrisma.prismaHelper) {
+    globalForPrisma.prismaHelper = new PrismaClient();
+  }
+  return globalForPrisma.prismaHelper;
+};
+
+const getDelegate = (client: PrismaClient, model: Prisma.ModelName) => {
+  const key = model.charAt(0).toLowerCase() + model.slice(1);
+  return (client as unknown as Record<string, unknown>)[key] as ReadDelegate | undefined;
+};
+
+const sanitizeData = (data: unknown): unknown => {
+  if (data === null || data === undefined) return null;
+  if (data instanceof Date) return data.toISOString();
+  if (typeof data === "bigint") return data.toString();
+  if (Array.isArray(data)) return data.map((item) => sanitizeData(item));
+  if (typeof data === "object") {
+    const entries = Object.entries(data as Record<string, unknown>)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [key, sanitizeData(value)]);
+    return Object.fromEntries(entries);
+  }
+  return data;
+};
+
+const extractStatusValue = (data: unknown): string | undefined => {
+  if (!data || typeof data !== "object") return undefined;
+
+  const payload = data as Record<string, unknown>;
+
+  for (const key of STATUS_KEYS) {
+    if (!(key in payload)) continue;
+    const value = payload[key];
+
+    if (value && typeof value === "object" && "set" in (value as Record<string, unknown>)) {
+      const setValue = (value as Record<string, unknown>).set;
+      if (typeof setValue === "string") return setValue;
+    }
+
+    if (typeof value === "string") return value;
+  }
+
+  return undefined;
+};
+
+const resolveAuditAction = (
+  defaultAction: AuditAction,
+  paramsAction: string,
+  data: unknown,
+): AuditAction => {
+  if (paramsAction === "update" || paramsAction === "updateMany") {
+    const statusValue = extractStatusValue(data);
+    if (statusValue) {
+      const normalized = statusValue.toUpperCase();
+      if (normalized === "APPROVED") return AuditAction.APPROVE;
+      if (normalized === "REJECTED") return AuditAction.REJECT;
+    }
+  }
+
+  return defaultAction;
+};
+
+const buildRecordIdentifier = (
+  model: Prisma.ModelName,
+  args: Record<string, unknown>,
+  result: unknown,
+): string | null => {
+  if (result && typeof result === "object" && "id" in (result as Record<string, unknown>)) {
+    const idValue = (result as Record<string, unknown>).id;
+    if (typeof idValue === "string" || typeof idValue === "number") {
+      return String(idValue);
+    }
+  }
+
+  if (args && typeof args === "object" && "where" in args) {
+    try {
+      return JSON.stringify((args as Record<string, unknown>).where ?? {});
+    } catch (error) {
+      console.warn(`[prisma] Unable to serialize record identifier for ${model}`, error);
+    }
+  }
+
+  return null;
+};
+
+const createPrismaClient = (): PrismaClient => {
+  const helperClient = ensureHelperClient();
+  const baseClient = new PrismaClient();
+
+  const extendedClient = baseClient.$extends({
+    query: {
+      $allModels: {
+        async $allOperations({ model, operation, args, query }) {
+          if (!model || !SOFT_DELETE_MODELS.has(model as Prisma.ModelName)) {
+            return query(args);
+          }
+
+          const modelName = model as Prisma.ModelName;
+          const delegate = getDelegate(helperClient, modelName);
+          const shouldLog = modelName !== "AuditLog" && Boolean(delegate);
+
+          const normalizedArgs = (args ?? {}) as Record<string, unknown>;
+          const ensureWhere = () => {
+            if (!("where" in normalizedArgs) || normalizedArgs.where === undefined) {
+              normalizedArgs.where = {};
+            }
+            return normalizedArgs.where as Record<string, unknown>;
+          };
+          const setDeletedFilter = () => {
+            const where = ensureWhere();
+            if (!("deletedAt" in where)) {
+              where.deletedAt = null;
+            }
+            return where;
+          };
+          const cloneWhere = () => {
+            const where = ensureWhere();
+            return JSON.parse(JSON.stringify(where));
+          };
+
+          const now = new Date();
+
+          let auditAction: AuditAction | null = null;
+          let beforeData: unknown;
+          let afterData: unknown;
+          let whereForLogging: Record<string, unknown> | undefined;
+
+          if (
+            operation === "findFirst" ||
+            operation === "findFirstOrThrow" ||
+            operation === "findMany" ||
+            operation === "count"
+          ) {
+            setDeletedFilter();
+          } else if (operation === "update" || operation === "updateMany") {
+            setDeletedFilter();
+            whereForLogging = cloneWhere();
+            if (shouldLog && delegate) {
+              if (operation === "update" && delegate.findFirst) {
+                beforeData = await delegate.findFirst({ where: whereForLogging });
+              }
+              if (operation === "updateMany" && delegate.findMany) {
+                beforeData = await delegate.findMany({ where: whereForLogging });
+              }
+            }
+            auditAction = AuditAction.UPDATE;
+          } else if (operation === "delete" || operation === "deleteMany") {
+            const where = setDeletedFilter();
+            whereForLogging = cloneWhere();
+
+            if (shouldLog && delegate) {
+              if (operation === "delete" && delegate.findFirst) {
+                beforeData = await delegate.findFirst({ where: whereForLogging });
+              }
+              if (operation === "deleteMany" && delegate.findMany) {
+                beforeData = await delegate.findMany({ where: whereForLogging });
+              }
+            }
+
+            auditAction = AuditAction.DELETE;
+
+            if (operation === "delete") {
+              const key = modelName.charAt(0).toLowerCase() + modelName.slice(1);
+              const modelDelegate = (helperClient as unknown as Record<string, unknown>)[key] as
+                | { update: (payload: Record<string, unknown>) => Promise<unknown> }
+                | undefined;
+              if (!modelDelegate?.update) {
+                console.warn(`[prisma] Missing update delegate for ${modelName}`);
+                return null;
+              }
+
+              const updateArgs = {
+                where,
+                data: { deletedAt: now },
+              };
+              const result = await modelDelegate.update(updateArgs);
+              afterData = result;
+
+              if (shouldLog) {
+                await maybeWriteAuditLog({
+                  action: auditAction,
+                  helperClient,
+                  modelName,
+                  operation,
+                  args: normalizedArgs,
+                  beforeData,
+                  afterData,
+                  result,
+                });
+              }
+
+              return result;
+            }
+
+            if (operation === "deleteMany") {
+              const key = modelName.charAt(0).toLowerCase() + modelName.slice(1);
+              const modelDelegate = (helperClient as unknown as Record<string, unknown>)[key] as
+                | { updateMany: (payload: Record<string, unknown>) => Promise<unknown> }
+                | undefined;
+              if (!modelDelegate?.updateMany) {
+                console.warn(`[prisma] Missing updateMany delegate for ${modelName}`);
+                return null;
+              }
+
+              const updateArgs = {
+                where,
+                data: { deletedAt: now },
+              };
+              const result = await modelDelegate.updateMany(updateArgs);
+
+              if (shouldLog && delegate?.findMany) {
+                afterData = await delegate.findMany({ where: whereForLogging });
+              }
+
+              if (shouldLog) {
+                await maybeWriteAuditLog({
+                  action: auditAction,
+                  helperClient,
+                  modelName,
+                  operation,
+                  args: normalizedArgs,
+                  beforeData,
+                  afterData,
+                  result,
+                });
+              }
+
+              return result;
+            }
+          } else if (operation === "create" || operation === "createMany") {
+            auditAction = AuditAction.CREATE;
+          }
+
+          const result = await query(normalizedArgs);
+
+          if (operation === "findUnique" || operation === "findUniqueOrThrow") {
+            if (
+              result &&
+              typeof result === "object" &&
+              "deletedAt" in (result as Record<string, unknown>) &&
+              (result as Record<string, unknown>).deletedAt !== null
+            ) {
+              if (operation === "findUniqueOrThrow") {
+                throw createNotFoundError(modelName);
+              }
+              return null;
+            }
+            return result;
+          }
+
+          if (!shouldLog || !auditAction) {
+            return result;
+          }
+
+          if (operation === "update" || operation === "updateMany" || auditAction === AuditAction.DELETE) {
+            const where = whereForLogging ?? cloneWhere();
+            if (delegate) {
+              if (operation === "update" && delegate.findFirst) {
+                afterData = await delegate.findFirst({ where });
+              } else if (delegate.findMany) {
+                afterData = await delegate.findMany({ where });
+              }
+            }
+          } else if (operation === "create") {
+            afterData = result;
+          } else if (operation === "createMany") {
+            afterData = normalizedArgs.data ?? result;
+          }
+
+          if (!afterData && (operation === "updateMany" || operation === "createMany")) {
+            const where = whereForLogging ?? cloneWhere();
+            if (delegate?.findMany) {
+              afterData = await delegate.findMany({ where });
+            }
+          }
+
+          await maybeWriteAuditLog({
+            action: auditAction,
+            helperClient,
+            modelName,
+            operation,
+            args: normalizedArgs,
+            beforeData,
+            afterData,
+            result,
+          });
+
+          return result;
+        },
+      },
+    },
+  });
+
+  return extendedClient as unknown as PrismaClient;
+};
+
+type AuditContext = {
+  action: AuditAction;
+  helperClient: PrismaClient;
+  modelName: Prisma.ModelName;
+  operation: string;
+  args: Record<string, unknown>;
+  beforeData: unknown;
+  afterData: unknown;
+  result: unknown;
+};
+
+const maybeWriteAuditLog = async ({
+  action,
+  helperClient,
+  modelName,
+  operation,
+  args,
+  beforeData,
+  afterData,
+  result,
+}: AuditContext) => {
+  if (modelName === "AuditLog") {
+    return;
+  }
+
+  const { data } = args as { data?: unknown };
+  const resolvedAction = resolveAuditAction(action, operation, data);
+  const recordId = buildRecordIdentifier(modelName, args, result);
+
+  try {
+    await helperClient.auditLog.create({
+      data: {
+        model: modelName,
+        action: resolvedAction,
+        recordId: recordId ?? undefined,
+        before: sanitizeData(beforeData) as Prisma.InputJsonValue,
+        after: sanitizeData(afterData ?? result) as Prisma.InputJsonValue,
+      },
+    });
+  } catch (error) {
+    console.error(`[prisma] Failed to record audit log for ${modelName}`);
+    console.error(error);
+  }
+};
+
+type NotFoundErrorLike = Error & { code?: string; meta?: Record<string, unknown> };
+
+const createNotFoundError = (modelName: Prisma.ModelName) => {
+  const error = new Error(`No ${modelName} found`) as NotFoundErrorLike;
+  error.name = "NotFoundError";
+  error.code = "P2025";
+  error.meta = { modelName };
+  return error;
+};
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+  ensureHelperClient();
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model User {
   roleDefinition RoleDefinition? @relation(fields: [roleDefinitionId], references: [id])
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
+  deletedAt      DateTime?
 }
 
 model Employee {
@@ -67,6 +68,7 @@ model Employee {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  deletedAt DateTime?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
@@ -85,7 +87,8 @@ model Account {
   id_token          String? @db.Text
   session_state     String?
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deletedAt DateTime?
 
   @@unique([provider, providerAccountId])
 }
@@ -96,13 +99,15 @@ model Session {
   userId       String
   expires      DateTime
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deletedAt DateTime?
 }
 
 model VerificationToken {
   identifier String
   token      String   @unique
   expires    DateTime
+  deletedAt  DateTime?
 
   @@unique([identifier, token])
 }
@@ -114,6 +119,7 @@ model RoleDefinition {
   description String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  deletedAt   DateTime?
 
   users       User[]
   permissions RolePermission[]
@@ -126,6 +132,7 @@ model Permission {
   description String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  deletedAt   DateTime?
 
   roles RolePermission[]
 
@@ -136,9 +143,29 @@ model RolePermission {
   roleId       String
   permissionId String
   assignedAt   DateTime @default(now())
+  deletedAt    DateTime?
 
   role       RoleDefinition @relation(fields: [roleId], references: [id], onDelete: Cascade)
   permission Permission     @relation(fields: [permissionId], references: [id], onDelete: Cascade)
 
   @@id([roleId, permissionId])
+}
+
+enum AuditAction {
+  CREATE
+  UPDATE
+  DELETE
+  APPROVE
+  REJECT
+}
+
+model AuditLog {
+  id          String      @id @default(cuid())
+  model       String
+  action      AuditAction
+  recordId    String?
+  before      Json?
+  after       Json?
+  performedAt DateTime    @default(now())
+  deletedAt   DateTime?
 }


### PR DESCRIPTION
## Summary
- replace the `$use` middleware with a `$extends`-based interceptor so Prisma clients without middleware support still enforce soft delete filters
- translate destructive actions into timestamp updates through the helper client while capturing before/after snapshots for audit logging
- update the audit log writer utilities to accept generic args, sanitize payloads for JSON inputs, and surface a consistent not-found error for deleted records

## Testing
- pnpm tsc --noEmit *(fails: numerous pre-existing module resolution/type errors for @mui icon imports)*

------
https://chatgpt.com/codex/tasks/task_e_68de182ac1008323bc042841c4bb4039